### PR TITLE
fix build with gcc 10

### DIFF
--- a/i7z.c
+++ b/i7z.c
@@ -34,6 +34,7 @@ int Dual_Socket();
 
 int socket_0_num=0, socket_1_num=1;
 bool use_ncurses = true;
+struct timespec global_ts;
 
 /////////////////////LOGGING TO FILE////////////////////////////////////////
 FILE *fp_log_file_freq;

--- a/i7z_Dual_Socket.c
+++ b/i7z_Dual_Socket.c
@@ -37,7 +37,7 @@ float Read_Voltage_CPU(int cpu_num);
 extern struct program_options prog_options;
 FILE *fp_log_file;
 
-struct timespec global_ts;
+extern struct timespec global_ts;
 extern FILE *fp_log_file_freq_1, *fp_log_file_freq_2;
 
 extern char* CPU_FREQUENCY_LOGGING_FILE_single;

--- a/i7z_Single_Socket.c
+++ b/i7z_Single_Socket.c
@@ -35,7 +35,7 @@ int Read_Thermal_Status_CPU(int cpu_num);
 extern struct program_options prog_options;
 extern FILE *fp_log_file_freq;
 
-struct timespec global_ts;
+extern struct timespec global_ts;
 
 extern char* CPU_FREQUENCY_LOGGING_FILE_single;
 extern char* CPU_FREQUENCY_LOGGING_FILE_dual;


### PR DESCRIPTION
Fix the following build failure with gcc 10 (which defaults to -fno-common):

/home/buildroot/autobuild/instance-2/output-1/host/bin/x86_64-linux-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -fno-schedule-insns2  -fno-schedule-insns -fno-inline-small-functions -fno-caller-saves -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DBUILD_MAIN -Wimplicit-function-declaration -Dx64_BIT  -o i7z i7z.o helper_functions.o i7z_Single_Socket.o i7z_Dual_Socket.o -lncurses -lpthread -lrt -lm
/home/buildroot/autobuild/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-gnu/10.2.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: i7z_Dual_Socket.o:(.bss+0x0): multiple definition of `global_ts'; i7z_Single_Socket.o:(.bss+0x0): first defined here

Fixes:
 - http://autobuild.buildroot.org/results/1a433611ba8676cf1ca276fccaf3633971bd562e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>